### PR TITLE
Raise the default keep n images to 10

### DIFF
--- a/cleanup/plugin.yaml
+++ b/cleanup/plugin.yaml
@@ -18,4 +18,4 @@ flags:
   - name: "keep"
     shorthand: "k"
     desc: "keep most current <n> images"
-    defValue: "3"
+    defValue: "10"


### PR DESCRIPTION
This leaves more images around for a possible roll back. The default
limit for number of images is 100.