### PR TITLE
Trigger building container-oc image on Docker Hub

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,22 @@
 # Travis CI has ShellCheck preinstalled.
 # (Other CIs need image: koalaman/shellcheck)
+language: generic
 
-before_script:
-- shellcheck --version
-- echo ----- */*.sh
+stages:
+- { name: lint }
+- { name: deploy, if: branch = master AND NOT type = pull_request }
 
-script:
-- shellcheck */*.sh
+jobs:
+  include:
+  - name: Lint shell scripts
+    stage: lint
+    before_script:
+    - shellcheck --version
+    - echo ----- */*.sh
+    script:
+    - shellcheck */*.sh
+
+  - name: Trigger container-oc build
+    stage: deploy
+    script:
+    - curl -H "Content-Type:application/json" --data '{"build":true}' -X POST "$DOCKERHUB_TRIGGER_URL"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 oc-plugins
 ==========
 
+[![Travis CI](https://img.shields.io/travis/appuio/oc-plugins/master.svg)](https://travis-ci.com/appuio/oc-plugins)
+[![container-oc Build](https://img.shields.io/docker/build/appuio/oc.svg)](https://hub.docker.com/r/appuio/oc/builds)
+
 A collection of plugins for the OKD / Kubernetes CLI client.
 
 1. `cleanup`: Clean up excessive (stale) resources


### PR DESCRIPTION
Updates the Travis CI configuration to trigger an image build on Docker Hub for [appuio/oc](https://hub.docker.com/r/appuio/oc/), which [pulls the latest version of this repo](https://github.com/appuio/container-oc/blob/master/src/Dockerfile#L21) from `master` each time an image build runs.

Related to: https://github.com/appuio/oc-plugins/pull/2#issuecomment-436728621